### PR TITLE
Badges, weekly streak colouring, quest bug fix

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -269,6 +269,8 @@ app.whenReady().then(() => {
   ipcMain.handle(CHANNELS.QUESTS_GET, () => getTodaySlate());
   ipcMain.handle(CHANNELS.QUESTS_HISTORY_GET, () => store.getAllQuestSlates());
 
+  ipcMain.handle(CHANNELS.STORE_GET_PRODUCTIVE_DAYS, () => store.getAllProductiveDays());
+
   // Settings handlers
   ipcMain.handle(CHANNELS.SETTINGS_OPEN, () => openSettingsWindow());
   ipcMain.handle(CHANNELS.SETTINGS_GET, () => readSettings());

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -49,6 +49,9 @@ const CHANNELS = {
   QUESTS_GET: 'quests:get',
   QUESTS_UPDATED: 'quests:updated',
   QUESTS_HISTORY_GET: 'quests:historyGet',
+
+  // Productive days (for weekly streak colouring)
+  STORE_GET_PRODUCTIVE_DAYS: 'store:getProductiveDays',
 };
 
 module.exports = { CHANNELS };

--- a/main/preload.js
+++ b/main/preload.js
@@ -76,4 +76,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('quests:updated', handler);
     return () => ipcRenderer.removeListener('quests:updated', handler);
   },
+
+  // Productive days (for weekly streak colouring)
+  getProductiveDays: () => ipcRenderer.invoke('store:getProductiveDays'),
 });

--- a/main/quests.js
+++ b/main/quests.js
@@ -502,9 +502,11 @@ const CONDITIONS = {
   // C-10: total session duration today >= target hours (in minutes)
   focused_hours(quest, data) {
     const targetMinutes = quest.targetValue * 60;
-    const totalMinutes = data.todaySessions.reduce(
-      (sum, s) => sum + (s.duration_minutes ?? 0), 0
-    );
+    const nowMs = Date.now();
+    const totalMinutes = data.todaySessions.reduce((sum, s) => {
+      const endMs = s.status === 'completed' ? s.ended_at : nowMs;
+      return sum + (endMs - s.started_at) / 60000;
+    }, 0);
     return { met: totalMinutes >= targetMinutes, progress: totalMinutes };
   },
 

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -69,6 +69,7 @@ export default function App() {
 
   const [badgeUnlocks, setBadgeUnlocks] = useState([]);
   const [questSlate, setQuestSlate] = useState(undefined);
+  const [productiveDays, setProductiveDays] = useState([]);
 
   // Today tab data fetched eagerly
   const [todaySessions, setTodaySessions] = useState(undefined);
@@ -103,6 +104,7 @@ export default function App() {
     if (!window.electronAPI) return;
     window.electronAPI.getBadgeUnlocks().then(records => setBadgeUnlocks(records ?? []));
     window.electronAPI.getQuestSlate().then(s => setQuestSlate(s ?? null));
+    window.electronAPI.getProductiveDays().then(days => setProductiveDays((days ?? []).map(d => d.day)));
     loadTodayData();
     const unsubBadges = window.electronAPI.onBadgesUpdated(records => setBadgeUnlocks(records ?? []));
     const unsubQuests = window.electronAPI.onQuestsUpdated(s => setQuestSlate(s ?? null));
@@ -115,6 +117,7 @@ export default function App() {
       setCompletedSession(session);
       setTab('timer');
       loadTodayData();
+      window.electronAPI.getProductiveDays().then(days => setProductiveDays((days ?? []).map(d => d.day)));
     });
     return cleanup;
   }, []);
@@ -216,7 +219,7 @@ export default function App() {
 
             {tab === 'quests' && (
               <div className="screen screen--quests">
-                <QuestsScreen questSlate={questSlate} badgeUnlocks={badgeUnlocks} />
+                <QuestsScreen questSlate={questSlate} badgeUnlocks={badgeUnlocks} productiveDays={productiveDays} />
               </div>
             )}
           </div>

--- a/renderer/src/components/QuestsScreen.jsx
+++ b/renderer/src/components/QuestsScreen.jsx
@@ -38,7 +38,7 @@ function getWeekDays() {
 
 const DAY_LABELS = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 
-export function QuestsScreen({ questSlate, badgeUnlocks = [] }) {
+export function QuestsScreen({ questSlate, badgeUnlocks = [], productiveDays = [] }) {
   const [now] = useState(Date.now());
 
   const quests = questSlate?.quests ?? [];
@@ -119,10 +119,20 @@ export function QuestsScreen({ questSlate, badgeUnlocks = [] }) {
             {weekDays.map(d => {
               const dayOfWeek = new Date(d + 'T12:00:00').getDay();
               const isToday = d === today;
+              const isProductive = productiveDays.includes(d);
+              const isPast = d < today;
+              const boxColor = isProductive
+                ? 'var(--sage)'
+                : isPast
+                  ? '#c0392b'
+                  : undefined;
               return (
                 <div key={d} className="wday">
                   <span className="wday-name">{DAY_LABELS[dayOfWeek]}</span>
-                  <div className={`wday-dot${isToday ? ' today' : ''}`} />
+                  <div
+                    className={`wday-dot${isToday ? ' today' : ''}`}
+                    style={boxColor ? { background: boxColor, borderColor: boxColor } : undefined}
+                  />
                 </div>
               );
             })}

--- a/renderer/src/components/QuestsScreen.jsx
+++ b/renderer/src/components/QuestsScreen.jsx
@@ -121,18 +121,11 @@ export function QuestsScreen({ questSlate, badgeUnlocks = [], productiveDays = [
               const isToday = d === today;
               const isProductive = productiveDays.includes(d);
               const isPast = d < today;
-              const boxColor = isProductive
-                ? 'var(--sage)'
-                : isPast
-                  ? '#c0392b'
-                  : undefined;
+              const stateClass = isProductive ? ' hit' : isPast ? ' miss' : '';
               return (
                 <div key={d} className="wday">
                   <span className="wday-name">{DAY_LABELS[dayOfWeek]}</span>
-                  <div
-                    className={`wday-dot${isToday ? ' today' : ''}`}
-                    style={boxColor ? { background: boxColor, borderColor: boxColor } : undefined}
-                  />
+                  <div className={`wday-dot${stateClass}${isToday && !isProductive ? ' today' : ''}`} />
                 </div>
               );
             })}

--- a/renderer/src/components/badgeIcons.jsx
+++ b/renderer/src/components/badgeIcons.jsx
@@ -22,7 +22,7 @@ const BADGE_ICONS = {
 
   first_blood: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#1a0a1a"/>
+
       <rect x="12" y="8" width="26" height="24" fill="#7a1a1a"/>
       <rect x="10" y="10" width="30" height="22" fill="#c02020"/>
       <rect x="12" y="8" width="26" height="4" fill="#e03030"/>
@@ -45,7 +45,7 @@ const BADGE_ICONS = {
 
   firestarter: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#1a0a00"/>
+
       <rect x="20" y="40" width="10" height="4" fill="#e06000"/>
       <rect x="18" y="36" width="14" height="4" fill="#e07000"/>
       <rect x="16" y="32" width="18" height="4" fill="#f08000"/>
@@ -71,7 +71,7 @@ const BADGE_ICONS = {
 
   the_refactorer: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0a1a"/>
+
       <rect x="8" y="20" width="6" height="4" fill="#6080c0"/>
       <rect x="8" y="18" width="4" height="2" fill="#8090d0"/>
       <rect x="10" y="16" width="4" height="2" fill="#8090d0"/>
@@ -97,7 +97,7 @@ const BADGE_ICONS = {
 
   deleter: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0a0a"/>
+
       <rect x="12" y="18" width="26" height="26" fill="#404040"/>
       <rect x="12" y="18" width="26" height="4" fill="#606060"/>
       <rect x="14" y="22" width="22" height="20" fill="#383838"/>
@@ -114,7 +114,7 @@ const BADGE_ICONS = {
 
   polyglot: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080818"/>
+
       <rect x="6" y="6" width="14" height="18" fill="#c0a000"/>
       <rect x="6" y="6" width="14" height="3" fill="#e0c000"/>
       <rect x="14" y="6" width="6" height="6" fill="#806800"/>
@@ -145,7 +145,7 @@ const BADGE_ICONS = {
 
   century: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0a00"/>
+
       <rect x="18" y="8" width="14" height="16" fill="#c8900c"/>
       <rect x="18" y="8" width="14" height="4" fill="#e0b020"/>
       <rect x="16" y="10" width="4" height="10" fill="#e0b020"/>
@@ -165,7 +165,7 @@ const BADGE_ICONS = {
 
   deep_cut: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0808"/>
+
       <rect x="8" y="22" width="30" height="6" fill="#9090a0"/>
       <rect x="8" y="22" width="30" height="2" fill="#c0c0d0"/>
       <rect x="34" y="18" width="8" height="4" fill="#a0a0b0"/>
@@ -190,7 +190,7 @@ const BADGE_ICONS = {
 
   creature_of_habit: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080c10"/>
+
       <rect x="8" y="10" width="34" height="32" fill="#1a2030"/>
       <rect x="8" y="10" width="34" height="6" fill="#4060c0"/>
       <rect x="8" y="16" width="34" height="2" fill="#2a3040"/>
@@ -216,7 +216,7 @@ const BADGE_ICONS = {
 
   iron_week: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080a10"/>
+
       <rect x="12" y="8" width="26" height="28" fill="#506070"/>
       <rect x="12" y="8" width="26" height="4" fill="#708090"/>
       <rect x="10" y="10" width="4" height="22" fill="#708090"/>
@@ -241,7 +241,7 @@ const BADGE_ICONS = {
 
   monthly_committer: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080810"/>
+
       <rect x="28" y="6" width="12" height="2" fill="#e0d080"/>
       <rect x="26" y="8" width="16" height="2" fill="#e8d890"/>
       <rect x="24" y="10" width="18" height="8" fill="#e8d890"/>
@@ -272,7 +272,7 @@ const BADGE_ICONS = {
 
   mono_tasker: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080c08"/>
+
       <rect x="10" y="20" width="30" height="10" fill="#203020"/>
       <rect x="12" y="18" width="26" height="14" fill="#284028"/>
       <rect x="16" y="16" width="18" height="4" fill="#40c040"/>
@@ -298,7 +298,7 @@ const BADGE_ICONS = {
 
   comeback_kid: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0810"/>
+
       <rect x="8" y="42" width="34" height="4" fill="#403020"/>
       <rect x="10" y="40" width="30" height="2" fill="#604030"/>
       <rect x="20" y="24" width="10" height="10" fill="#e06020"/>
@@ -325,7 +325,7 @@ const BADGE_ICONS = {
 
   early_bird: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080818"/>
+
       <rect x="0" y="28" width="50" height="22" fill="#1a0a2a"/>
       <rect x="0" y="26" width="50" height="4" fill="#3a1a4a"/>
       <rect x="14" y="22" width="22" height="6" fill="#f09030"/>
@@ -347,7 +347,7 @@ const BADGE_ICONS = {
 
   night_owl: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#040414"/>
+
       <rect x="8" y="6" width="2" height="2" fill="#e0e0f0"/>
       <rect x="18" y="4" width="2" height="2" fill="#c0c0e0"/>
       <rect x="30" y="8" width="2" height="2" fill="#e0e0f0"/>
@@ -386,7 +386,7 @@ const BADGE_ICONS = {
 
   deep_work: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080c10"/>
+
       <rect x="12" y="6" width="26" height="4" fill="#8060c0"/>
       <rect x="14" y="10" width="22" height="2" fill="#6040a0"/>
       <rect x="16" y="12" width="18" height="2" fill="#c0a020"/>
@@ -410,7 +410,7 @@ const BADGE_ICONS = {
 
   marathon: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0808"/>
+
       <rect x="28" y="6" width="6" height="6" fill="#e0b080"/>
       <rect x="26" y="12" width="8" height="8" fill="#2060d0"/>
       <rect x="18" y="14" width="8" height="4" fill="#2060d0"/>
@@ -441,7 +441,7 @@ const BADGE_ICONS = {
 
   lunch_break_hacker: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#0a0c08"/>
+
       <rect x="8" y="28" width="34" height="2" fill="#505050"/>
       <rect x="8" y="22" width="34" height="6" fill="#303030"/>
       <rect x="10" y="14" width="30" height="14" fill="#202020"/>
@@ -465,7 +465,7 @@ const BADGE_ICONS = {
 
   ghost_mode: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#060810"/>
+
       <rect x="14" y="12" width="22" height="2" fill="#c0c0e0" opacity="0.6"/>
       <rect x="12" y="14" width="26" height="2" fill="#d0d0f0" opacity="0.7"/>
       <rect x="10" y="16" width="30" height="16" fill="#c0c0e0" opacity="0.65"/>
@@ -489,7 +489,7 @@ const BADGE_ICONS = {
 
   greenfield: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080c08"/>
+
       <rect x="0" y="36" width="50" height="14" fill="#1a3010"/>
       <rect x="0" y="34" width="50" height="2" fill="#2a5020"/>
       <rect x="8" y="24" width="4" height="10" fill="#308040"/>
@@ -515,7 +515,7 @@ const BADGE_ICONS = {
 
   silent_majority: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#08080c"/>
+
       <rect x="8" y="8" width="34" height="26" fill="#1a1a2a"/>
       <rect x="8" y="8" width="34" height="4" fill="#2a2a3a"/>
       <rect x="6" y="10" width="4" height="20" fill="#2a2a3a"/>
@@ -538,7 +538,7 @@ const BADGE_ICONS = {
 
   the_cleaner: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080808"/>
+
       <rect x="32" y="6" width="4" height="4" fill="#a06030"/>
       <rect x="30" y="10" width="4" height="4" fill="#a06030"/>
       <rect x="28" y="14" width="4" height="4" fill="#906020"/>
@@ -564,7 +564,7 @@ const BADGE_ICONS = {
 
   level_up_unlocked: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080c18"/>
+
       <rect x="22" y="8" width="6" height="26" fill="#60a0f0"/>
       <rect x="16" y="18" width="6" height="4" fill="#60a0f0"/>
       <rect x="28" y="18" width="6" height="4" fill="#60a0f0"/>
@@ -589,7 +589,7 @@ const BADGE_ICONS = {
 
   principal_engineer: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#08080c"/>
+
       <rect x="20" y="6" width="10" height="2" fill="#c0d0ff"/>
       <rect x="16" y="8" width="18" height="4" fill="#d0e0ff"/>
       <rect x="12" y="12" width="26" height="10" fill="#e0f0ff"/>
@@ -613,7 +613,7 @@ const BADGE_ICONS = {
 
   ten_thousand_lines: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#080c08"/>
+
       <rect x="6" y="34" width="6" height="8" fill="#4080c0"/>
       <rect x="14" y="28" width="6" height="14" fill="#4090d0"/>
       <rect x="22" y="22" width="6" height="20" fill="#40a0e0"/>
@@ -634,7 +634,7 @@ const BADGE_ICONS = {
 
   session_centurion: (
     <svg width="36" height="36" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" shapeRendering="crispEdges">
-      <rect width="50" height="50" fill="#100808"/>
+
       <rect x="22" y="4" width="6" height="2" fill="#d04040"/>
       <rect x="20" y="6" width="10" height="2" fill="#e05050"/>
       <rect x="18" y="8" width="14" height="4" fill="#e06060"/>

--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -2250,14 +2250,12 @@ body {
   font-size: 13px;
   font-family: var(--font-ui);
   image-rendering: pixelated;
-  transition: box-shadow 0.1s step-end;
 }
 
 .wday-dot.hit {
   background: var(--streak-hit-dk);
   border-color: var(--streak-hit);
   color: var(--streak-hit);
-  box-shadow: 0 0 6px 1px var(--streak-hit-glow), inset 0 0 4px rgba(0,230,118,0.2);
 }
 
 .wday-dot.hit::after {
@@ -2268,7 +2266,6 @@ body {
   background: var(--streak-miss-dk);
   border-color: var(--streak-miss);
   color: var(--streak-miss);
-  box-shadow: 0 0 6px 1px var(--streak-miss-glow), inset 0 0 4px rgba(255,23,68,0.15);
 }
 
 .wday-dot.miss::after {

--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -38,6 +38,12 @@
   --hm-2: #6ab878;
   --hm-3: #389050;
   --hm-4: #1a6a38;
+  --streak-hit: #00e676;
+  --streak-hit-dk: #00701a;
+  --streak-hit-glow: rgba(0, 230, 118, 0.45);
+  --streak-miss: #ff1744;
+  --streak-miss-dk: #7f0014;
+  --streak-miss-glow: rgba(255, 23, 68, 0.35);
 }
 
 [data-theme="twilight"] {
@@ -65,6 +71,12 @@
   --hm-3: #428e5a;
   --hm-4: #60c878;
   --scrollbar: rgba(200, 155, 255, 0.2);
+  --streak-hit: #00e676;
+  --streak-hit-dk: #004d1a;
+  --streak-hit-glow: rgba(0, 230, 118, 0.55);
+  --streak-miss: #ff1744;
+  --streak-miss-dk: #4d0010;
+  --streak-miss-glow: rgba(255, 23, 68, 0.45);
 }
 
 /* ─── Base ───────────────────────────────────────────────────── */
@@ -2228,25 +2240,39 @@ body {
 }
 
 .wday-dot {
-  width: 22px;
-  height: 22px;
-  border: 1px solid var(--dim);
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--dim);
   background: var(--bar-track);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
-  font-family: monospace;
+  font-size: 13px;
+  font-family: var(--font-ui);
+  image-rendering: pixelated;
+  transition: box-shadow 0.1s step-end;
 }
 
-.wday-dot.done {
-  background: var(--sage);
-  border-color: var(--sage-dk);
-  color: rgba(255, 255, 200, 0.9);
+.wday-dot.hit {
+  background: var(--streak-hit-dk);
+  border-color: var(--streak-hit);
+  color: var(--streak-hit);
+  box-shadow: 0 0 6px 1px var(--streak-hit-glow), inset 0 0 4px rgba(0,230,118,0.2);
 }
 
-.wday-dot.done::after {
-  content: "★";
+.wday-dot.hit::after {
+  content: "✓";
+}
+
+.wday-dot.miss {
+  background: var(--streak-miss-dk);
+  border-color: var(--streak-miss);
+  color: var(--streak-miss);
+  box-shadow: 0 0 6px 1px var(--streak-miss-glow), inset 0 0 4px rgba(255,23,68,0.15);
+}
+
+.wday-dot.miss::after {
+  content: "✕";
 }
 
 .wday-dot.today {


### PR DESCRIPTION
## Summary
- Remove black backgrounds from all 24 badge SVG icons (transparent backgrounds)
- Weekly streak day boxes now colour green (hit) / red (miss) based on productive days, with video-game pixel-art style
- Fix `focused_hours` quest incorrectly completing early — was using configured timer duration instead of actual elapsed time

## Changes
- `renderer/src/components/badgeIcons.jsx` — removed background rects from all badge SVGs
- `main/ipc.js`, `main/index.js`, `main/preload.js` — new `store:getProductiveDays` IPC endpoint
- `renderer/src/App.jsx` — fetch and pass productive days to QuestsScreen
- `renderer/src/components/QuestsScreen.jsx` — colour day boxes using hit/miss CSS classes
- `renderer/src/index.css` — new `--streak-hit` / `--streak-miss` theme variables and `.wday-dot.hit` / `.wday-dot.miss` styles
- `main/quests.js` — fix `focused_hours` to use `ended_at - started_at` for real elapsed time