### PR TITLE
UI improvements: stats layout, weekly streak, config tab, badge grid

### DIFF
--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -26,11 +26,10 @@ import { FocusScreen } from './components/FocusScreen';
 import { QuestsScreen } from './components/QuestsScreen';
 
 // Settings window loads the same renderer with ?view=settings
-const isSettingsWindow = new URLSearchParams(window.location.search).get('view') === 'settings';
-
 const TABS = [
   { id: 'timer',  label: '[ Focus ]'  },
   { id: 'today',  label: '[ Stats ]'  },
+  { id: 'config', label: '[ Config ]' },
 ];
 
 function getThemeByTime() {
@@ -47,20 +46,6 @@ function getInitialTheme() {
 }
 
 export default function App() {
-  if (isSettingsWindow) {
-    const theme = getInitialTheme();
-    return (
-      <div className="app-shell" data-theme={theme}>
-        <BackgroundScene theme={theme} />
-        <div className="panel">
-          <div className="app-content app-content--settings">
-            <Settings />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   const { timeLeft, totalSeconds, status, type, start, pause, reset: resetTimer, stop, startShortBreak, startLongBreak } = useTimer();
   const [tab, setTab] = useState('timer');
   const [completedSession, setCompletedSession] = useState(null);
@@ -184,7 +169,7 @@ export default function App() {
                   onSelectFocus={stop}
                   onSelectShortBreak={startShortBreak}
                   onSelectLongBreak={startLongBreak}
-                  onConfig={() => window.electronAPI?.openSettings()}
+                  onConfig={() => setTab('config')}
                   todaySessions={todaySessions}
                   todayCommits={todayCommits}
                   todayXp={todayXp}
@@ -219,6 +204,12 @@ export default function App() {
             {tab === 'week' && (
               <div className="screen screen--week">
                 <WeekDigest />
+              </div>
+            )}
+
+            {tab === 'config' && (
+              <div className="screen screen--config">
+                <Settings />
               </div>
             )}
 

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -31,7 +31,6 @@ const isSettingsWindow = new URLSearchParams(window.location.search).get('view')
 const TABS = [
   { id: 'timer',  label: '[ Focus ]'  },
   { id: 'today',  label: '[ Stats ]'  },
-  { id: 'quests', label: '[ Quests ]' },
 ];
 
 function getThemeByTime() {
@@ -189,6 +188,7 @@ export default function App() {
                   todaySessions={todaySessions}
                   todayCommits={todayCommits}
                   todayXp={todayXp}
+                  allSessions={allSessions}
                 />
               </div>
             )}
@@ -222,11 +222,6 @@ export default function App() {
               </div>
             )}
 
-            {tab === 'quests' && (
-              <div className="screen screen--quests">
-                <QuestsScreen questSlate={questSlate} badgeUnlocks={badgeUnlocks} productiveDays={productiveDays} allSessions={allSessions} />
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/renderer/src/components/DayTimeline.jsx
+++ b/renderer/src/components/DayTimeline.jsx
@@ -171,36 +171,16 @@ export function DayTimeline({ questSlate, badgeUnlocks = [], sessions, allSessio
         ))}
       </div>
 
-      {/* ── Bottom 2-column: Heatmap + Badges ── */}
-      <div className="dash-bottom">
-        {/* Heatmap */}
-        <div className="card" style={{ padding: '14px' }}>
-          <div className="sec-title">Focus Heatmap — 12 Weeks</div>
-          <HeatmapGrid sessions={allSessions} />
-          <div style={{ display: 'flex', gap: '5px', alignItems: 'center', marginTop: '8px' }}>
-            <span style={{ fontSize: '8px', color: 'var(--muted)' }}>Less</span>
-            {['hm','hm hm1','hm hm2','hm hm3','hm hm4'].map((c,i) => (
-              <div key={i} className={c} style={{ width: '9px', height: '9px' }} />
-            ))}
-            <span style={{ fontSize: '8px', color: 'var(--muted)' }}>More</span>
-          </div>
-        </div>
-
-        {/* Badge grid */}
-        <div className="card" style={{ padding: '14px' }}>
-          <div className="sec-title">Badges Earned</div>
-          <div className="dash-badge-grid">
-            {BADGE_DEFS.slice(0, 6).map(b => {
-              const earned = unlockedSlugs.has(b.slug);
-              return (
-                <div key={b.slug} className={`gb${earned ? ' earned' : ' locked'}`}>
-                  <div className="gb-ico"><BadgeIcon slug={b.slug} locked={!earned} /></div>
-                  <div className="gb-name">{b.name}</div>
-                  <div className="gb-xp num">{b.xp ?? 50} XP</div>
-                </div>
-              );
-            })}
-          </div>
+      {/* ── Heatmap (full width) ── */}
+      <div className="card" style={{ padding: '14px' }}>
+        <div className="sec-title">Focus Heatmap — 12 Weeks</div>
+        <HeatmapGrid sessions={allSessions} />
+        <div style={{ display: 'flex', gap: '5px', alignItems: 'center', marginTop: '8px' }}>
+          <span style={{ fontSize: '8px', color: 'var(--muted)' }}>Less</span>
+          {['hm','hm hm1','hm hm2','hm hm3','hm hm4'].map((c,i) => (
+            <div key={i} className={c} style={{ width: '12px', height: '12px' }} />
+          ))}
+          <span style={{ fontSize: '8px', color: 'var(--muted)' }}>More</span>
         </div>
       </div>
 
@@ -259,6 +239,23 @@ export function DayTimeline({ questSlate, badgeUnlocks = [], sessions, allSessio
           <RepoCommitList repos={repos} sessionWindows={sessionWindows} />
         </div>
       )}
+
+      {/* ── Badge grid ── */}
+      <div className="card" style={{ padding: '14px' }}>
+        <div className="sec-title">Badges Earned</div>
+        <div className="dash-badge-grid">
+          {BADGE_DEFS.slice(0, 6).map(b => {
+            const earned = unlockedSlugs.has(b.slug);
+            return (
+              <div key={b.slug} className={`gb${earned ? ' earned' : ' locked'}`}>
+                <div className="gb-ico"><BadgeIcon slug={b.slug} locked={!earned} /></div>
+                <div className="gb-name">{b.name}</div>
+                <div className="gb-xp num">{b.xp ?? 50} XP</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/renderer/src/components/DayTimeline.jsx
+++ b/renderer/src/components/DayTimeline.jsx
@@ -244,7 +244,10 @@ export function DayTimeline({ questSlate, badgeUnlocks = [], sessions, allSessio
       <div className="card" style={{ padding: '14px' }}>
         <div className="sec-title">Badges Earned</div>
         <div className="dash-badge-grid">
-          {BADGE_DEFS.slice(0, 6).map(b => {
+          {[
+            ...BADGE_DEFS.filter(b => unlockedSlugs.has(b.slug)),
+            ...BADGE_DEFS.filter(b => !unlockedSlugs.has(b.slug)),
+          ].map(b => {
             const earned = unlockedSlugs.has(b.slug);
             return (
               <div key={b.slug} className={`gb${earned ? ' earned' : ' locked'}`}>

--- a/renderer/src/components/FocusScreen.jsx
+++ b/renderer/src/components/FocusScreen.jsx
@@ -1,6 +1,21 @@
 import React from 'react';
 import { TomatoSprite, getTomatoState } from './TomatoSprite';
 
+const DAY_LABELS = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+function localDateStr(d) {
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+
+function getWeekDays() {
+  const today = new Date();
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() - (6 - i));
+    return localDateStr(d);
+  });
+}
+
 // Flatten all commits from dayCommits into a flat list with repo name attached
 function flatCommits(dayCommits) {
   if (!dayCommits?.repos) return [];
@@ -21,7 +36,7 @@ function isInSession(timestamp, sessionWindows) {
 export function FocusScreen({
   timeLeft, totalSeconds, status, type,
   onStart, onPause, onReset, onSelectFocus, onSelectShortBreak, onSelectLongBreak, onConfig,
-  todaySessions, todayCommits, todayXp,
+  todaySessions, todayCommits, todayXp, allSessions = [],
 }) {
   const progress = totalSeconds > 0 ? timeLeft / totalSeconds : 1;
   const spriteState = getTomatoState(progress);
@@ -39,6 +54,17 @@ export function FocusScreen({
   const xpToday = todayXp?.xp ?? 0;
 
   const commits = flatCommits(todayCommits);
+
+  // Weekly streak — days with any commit
+  const today = localDateStr(new Date());
+  const weekDays = getWeekDays();
+  const daysWithCommits = new Set();
+  allSessions.forEach(s => {
+    if (s.type !== 'focus') return;
+    const repos = Array.isArray(s.repos) ? s.repos : [];
+    if (!repos.some(r => (r.commits?.length ?? 0) > 0)) return;
+    daysWithCommits.add(localDateStr(new Date(s.started_at)));
+  });
 
   const phaseLabel = type === 'focus'
     ? '▶ Deep Focus Mode'
@@ -173,6 +199,26 @@ export function FocusScreen({
           <div className="card focus-stat">
             <span className="focus-stat__val num">{todayLines}</span>
             <span className="focus-stat__lbl">Lines</span>
+          </div>
+        </div>
+
+        {/* Weekly streak */}
+        <div className="card quests-streak">
+          <div className="sec-title" style={{ marginBottom: '10px' }}>Weekly Streak</div>
+          <div className="quests-streak__days">
+            {weekDays.map(d => {
+              const dayOfWeek = new Date(d + 'T12:00:00').getDay();
+              const isToday = d === today;
+              const hasCommit = daysWithCommits.has(d);
+              const isPast = d < today;
+              const stateClass = hasCommit ? ' hit' : isPast ? ' miss' : '';
+              return (
+                <div key={d} className="wday">
+                  <span className="wday-name">{DAY_LABELS[dayOfWeek]}</span>
+                  <div className={`wday-dot${stateClass}${isToday && !hasCommit ? ' today' : ''}`} />
+                </div>
+              );
+            })}
           </div>
         </div>
 

--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -937,7 +937,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  overflow: hidden;
+  overflow-y: auto;
   min-height: 0;
 }
 

--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -407,6 +407,10 @@ body {
   overflow: hidden;
 }
 
+.screen--config {
+  overflow-y: auto;
+}
+
 .screen--sc {
   overflow-y: auto;
 }

--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -72,11 +72,11 @@
   --hm-4: #60c878;
   --scrollbar: rgba(200, 155, 255, 0.2);
   --streak-hit: #00e676;
-  --streak-hit-dk: #004d1a;
-  --streak-hit-glow: rgba(0, 230, 118, 0.55);
-  --streak-miss: #ff1744;
-  --streak-miss-dk: #7a1828;
-  --streak-miss-glow: rgba(255, 23, 68, 0.45);
+  --streak-hit-dk: #00701a;
+  --streak-hit-glow: rgba(0, 230, 118, 0.45);
+  --streak-miss: #fff;
+  --streak-miss-dk: #c3263c;
+  --streak-miss-glow: rgba(255, 23, 68, 0.35);
 }
 
 /* ─── Base ───────────────────────────────────────────────────── */
@@ -1511,8 +1511,8 @@ body {
 
 /* Heatmap cells */
 .hm {
-  width: 11px;
-  height: 11px;
+  width: 22px;
+  height: 22px;
   background: var(--hm-0);
 }
 


### PR DESCRIPTION
## Summary
- Stats page: full-width heatmap, badges moved after commits today, larger heatmap squares (22px)
- Badges Earned grid now shows all badges — earned first (highlighted), unearned after
- Weekly streak moved from the removed Quests tab into the Focus tab, above XP Today
- Quests tab removed from nav
- Config no longer opens in a popup window — it's an inline tab beside Stats

## Changes
- `renderer/src/components/DayTimeline.jsx` — stats layout restructure, full badge list
- `renderer/src/components/FocusScreen.jsx` — weekly streak added to right column
- `renderer/src/App.jsx` — quests tab removed, config tab added, settings popup path removed
- `renderer/src/index.css` — screen--config rule added